### PR TITLE
Handle short commands with leading dot

### DIFF
--- a/Syntaxes/mumps.tmLanguage
+++ b/Syntaxes/mumps.tmLanguage
@@ -20,7 +20,7 @@
 			<key>comment</key>
 			<string>uses positive look behind (leading space) and positive look ahead (space, :, or $)</string>
 			<key>match</key>
-			<string>(?&lt;=\s)(?i:[BCDEFGHIJKLMNOQRSUVWX])(?=(:|\s|$))</string>
+			<string>(?&lt;=[\s.])(?i:[BCDEFGHIJKLMNOQRSUVWX])(?=(:|\s|$))</string>
 			<key>name</key>
 			<string>keyword.mumps.short</string>
 		</dict>


### PR DESCRIPTION
Handle short commands that are indented with `.`, without a space.

Example:

```
i x="" d
.s y="A" ; This s should be marked as keyword.mumps.short
```